### PR TITLE
fix: show message if photo is not uploaded

### DIFF
--- a/src/components/ViewSidebar.js
+++ b/src/components/ViewSidebar.js
@@ -5,6 +5,7 @@ import './ViewSidebar.scss';
 
 const ViewSidebar = (props) => {
 	console.log(props.data)
+	const profile_image_url = props.data.profile_image_url;
 	let top = (
 		<React.Fragment>
 			<div className='sidebar-header-1'>
@@ -12,10 +13,10 @@ const ViewSidebar = (props) => {
 			</div>
 			<div className='sidebar-body'>
 				<div className='sidebar-pic'>
-					   <img className="photo"
-	                    src={props.data.profile_image_url}
+					   {profile_image_url ? <img className="photo"
+	                    src={profile_image_url}
 	                    alt="victim"
-	                  />
+	                  /> : "No photo available"}
 				</div>
 				<div className='sidebar-header-2'>
 					<p> {props.data.name} </p>

--- a/src/pages/Victims.js
+++ b/src/pages/Victims.js
@@ -152,11 +152,11 @@ const Victims = (props) => {
 	            {victimList && victimList.length !== 0? victimList.map((item, index) => (
 	              <li key={item.id}>
 					<div className="col">
-	                  {item.url &&
+	                  {item.url ?
 					  <img className="photo"
 	                    src={item.url}
 	                    alt="victim"
-	                  />}
+	                  />: "No photo available"}
 	                </div>
 	                <div className="col">
 	                  <div className="name"><span>Name:</span> {item.name}</div>


### PR DESCRIPTION
A message 'No photo available' will be shown if no victim photo was uploaded. This addresses the issue in card: [https://trello.com/c/D45Pdhud/144-add-a-message-or-other-thing-if-the-victim-report-doesnt-have-a-profile-photo](url)